### PR TITLE
libc: don't try to set SELinux fs xattr which we're not using anyway

### DIFF
--- a/libc/bionic/system_properties.cpp
+++ b/libc/bionic/system_properties.cpp
@@ -238,6 +238,8 @@ static prop_area* map_prop_area_rw(const char* filename, const char* context,
         return nullptr;
     }
 
+
+#if DISABLED_FOR_ANBOX
     if (context) {
         if (fsetxattr(fd, XATTR_NAME_SELINUX, context, strlen(context) + 1, 0) != 0) {
             __libc_format_log(ANDROID_LOG_ERROR, "libc",
@@ -256,6 +258,10 @@ static prop_area* map_prop_area_rw(const char* filename, const char* context,
             }
         }
     }
+#else
+    (void) context;
+    (void) fsetxattr_failed;
+#endif
 
     if (ftruncate(fd, PA_SIZE) < 0) {
         close(fd);


### PR DESCRIPTION
This fails on a few systems for unknown reasons (kernel configuration?)

Change-Id: Idc1974549a11674ae4889d205b983831007c8d9e